### PR TITLE
Remove further references to homepage top story

### DIFF
--- a/wp-content/themes/ipbs-largo/homepages/template.php
+++ b/wp-content/themes/ipbs-largo/homepages/template.php
@@ -8,13 +8,11 @@
  */
 
 global $shown_ids;
-$topstory = largo_home_single_top();
-$shown_ids[] = $topstory->ID;
 
 ?>
 <div class="">
-	<div id="top-story" <?php post_class( '', $topstory->ID ); ?> >
-		<?php if (true ) { ?>
+	<div id="top-story" class="has-post-thumbnail" >
+		<?php if ( true ) { ?>
 			<div class="post-image-top-term-container" aria-hidden="true">
 				<img
 					src="<?php echo esc_url( get_stylesheet_directory_uri() . '/images/homepage-halved.jpg' ); ?>"


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Stops the homepage top template from relying on `post_class()` for the top story to generate the `has-post-thumbnail` class

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #55 

Because on staging, which had no top post with a thumbnail set, the template was appearing as it should when there is no background image:

![Screen Shot 2020-02-04 at 16 21 27](https://user-images.githubusercontent.com/1754187/73788212-9f1ffa80-476a-11ea-9f29-2d782651a697.png)


## Testing/Questions

Features that this PR affects:

- homepage

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [x] are there any other references to `$topstory` in the codebase that need to be removed?

Steps to test this PR:

1. Just check it out.