### PR TITLE
Update job archive title, remove hardcoded "jobs" from single partial

### DIFF
--- a/wp-content/themes/ipbs-largo/functions.php
+++ b/wp-content/themes/ipbs-largo/functions.php
@@ -70,7 +70,7 @@ add_filter( 'largo_partial_by_post_type', 'add_ipbs_jobs_custom_partial', 10, 3 
  */
 function update_ipbs_jobs_archive_title( $title ){
 
-	$title = 'Job Boards';
+	$title = 'Employment Opportunities';
 	return $title;
 
 }

--- a/wp-content/themes/ipbs-largo/partials/content-single-job.php
+++ b/wp-content/themes/ipbs-largo/partials/content-single-job.php
@@ -12,7 +12,7 @@
 
 		<?php largo_maybe_top_term(); ?>
 
-		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?> job</h1>
+		<h1 class="entry-title" itemprop="headline"><?php the_title(); ?></h1>
 		<?php if ( $subtitle = get_post_meta( $post->ID, 'subtitle', true ) ) : ?>
 			<h2 class="subtitle"><?php echo $subtitle ?></h2>
 		<?php endif; ?>


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates `Job Boards` title to `Employment Opportunities` on jobs archive
- Removes hardcoded `job` from single job partial title

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #95 

## Testing/Questions

Features that this PR affects:

- Jobs archive
- Single jobs partial

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. View the jobs archive and make sure the new title looks ok
2. View a single job and make sure the title looks ok